### PR TITLE
Indented the code to 4 spaces across all files

### DIFF
--- a/fractal.py
+++ b/fractal.py
@@ -166,6 +166,7 @@ def img2output(img, cmap=DEFAULT_COLORMAP, output=None, show=False):
     if show:
         pylab.imshow(img, cmap=cmap)
         pylab.show()
+    return
 
 
 def call_kw(func, kwargs):
@@ -178,7 +179,7 @@ def call_kw(func, kwargs):
 def exec_command(kwargs):
     """ Fractal command from a dictionary of keyword arguments (from CLI) """
     kwargs["img"] = call_kw(generate_fractal, kwargs)
-    call_kw(img2output, kwargs)
+    return call_kw(img2output, kwargs)
 
 
 def cli_parse_args(args=None, namespace=None):

--- a/fractal.py
+++ b/fractal.py
@@ -7,16 +7,17 @@
 Julia and Mandelbrot fractals image creation
 """
 
+
 from __future__ import division, print_function
 import pylab, argparse, collections, inspect, functools
 from itertools import takewhile
 import time
 import multiprocessing
-
 Point = collections.namedtuple("Point", ["x", "y"])
 
+
 def pair_reader(dtype):
-  return lambda data: Point(*map(dtype, data.lower().split("x")))
+    return lambda data: Point(*map(dtype, data.lower().split("x")))
 
 
 DEFAULT_SIZE = "512x512"
@@ -27,218 +28,219 @@ DEFAULT_COLORMAP = "cubehelix"
 
 
 def repeater(f):
-  """
-  Returns a generator function that returns a repeated function composition
-  iterator (generator) for the function given, i.e., for a function input
-  ``f`` with one parameter ``n``, calling ``repeater(f)(n)`` yields the
-  values (one at a time)::
+    """
+    Returns a generator function that returns a repeated function composition
+    iterator (generator) for the function given, i.e., for a function input
+    ``f`` with one parameter ``n``, calling ``repeater(f)(n)`` yields the
+    values (one at a time)::
 
-     n, f(n), f(f(n)), f(f(f(n))), ...
+       n, f(n), f(f(n)), f(f(f(n))), ...
 
-  Examples
-  --------
+    Examples
+    --------
 
-  >>> func = repeater(lambda x: x ** 2 - 1)
-  >>> func
-  <function ...>
-  >>> gen = func(3)
-  >>> gen
-  <generator object ...>
-  >>> next(gen)
-  3
-  >>> next(gen) # 3 ** 2 - 1
-  8
-  >>> next(gen) # 8 ** 2 - 1
-  63
-  >>> next(gen) # 63 ** 2 - 1
-  3968
+    >>> func = repeater(lambda x: x ** 2 - 1)
+    >>> func
+    <function ...>
+    >>> gen = func(3)
+    >>> gen
+    <generator object ...>
+    >>> next(gen)
+    3
+    >>> next(gen) # 3 ** 2 - 1
+    8
+    >>> next(gen) # 8 ** 2 - 1
+    63
+    >>> next(gen) # 63 ** 2 - 1
+    3968
 
-  """
-  @functools.wraps(f)
-  def wrapper(n):
-    val = n
-    while True:
-      yield val
-      val = f(val)
-  return wrapper
+    """
+    @functools.wraps(f)
+    def wrapper(n):
+        val = n
+        while True:
+            yield val
+            val = f(val)
+    return wrapper
 
 
 def amount(gen, limit=float("inf")):
-  """
-  Iterates through ``gen`` returning the amount of elements in it. The
-  iteration stops after at least ``limit`` elements had been iterated.
+    """
+    Iterates through ``gen`` returning the amount of elements in it. The
+    iteration stops after at least ``limit`` elements had been iterated.
 
-  Examples
-  --------
+    Examples
+    --------
 
-  >>> amount(x for x in "abc")
-  3
-  >>> amount((x for x in "abc"), 2)
-  2
-  >>> from itertools import count
-  >>> amount(count(), 5) # Endless, always return ceil(limit)
-  5
-  >>> amount(count(start=3, step=19), 18.2)
-  19
-  """
-  size = 0
-  for unused in gen:
-    size += 1
-    if size >= limit:
-      break
-  return size
+    >>> amount(x for x in "abc")
+    3
+    >>> amount((x for x in "abc"), 2)
+    2
+    >>> from itertools import count
+    >>> amount(count(), 5) # Endless, always return ceil(limit)
+    5
+    >>> amount(count(start=3, step=19), 18.2)
+    19
+    """
+    size = 0
+    for unused in gen:
+        size += 1
+        if size >= limit:
+            break
+    return size
 
 
 def in_circle(radius):
-  """ Returns ``abs(z) < radius`` boolean value function for a given ``z`` """
-  return lambda z: z.real ** 2 + z.imag ** 2 < radius ** 2
+    """ Returns ``abs(z) < radius`` boolean value function for a given ``z`` """
+    return lambda z: z.real ** 2 + z.imag ** 2 < radius ** 2
 
 
 def fractal_eta(z, func, limit, radius=2):
-  """
-  Fractal Escape Time Algorithm for pixel (x, y) at z = ``x + y * 1j``.
-  Returns the fractal value up to a ``limit`` iteration depth.
-  """
-  return amount(takewhile(in_circle(radius), repeater(func)(z)), limit)
+    """
+    Fractal Escape Time Algorithm for pixel (x, y) at z = ``x + y * 1j``.
+    Returns the fractal value up to a ``limit`` iteration depth.
+    """
+    return amount(takewhile(in_circle(radius), repeater(func)(z)), limit)
 
 
 def cqp(c):
-  """ Complex quadratic polynomial, function used for Mandelbrot fractal """
-  return lambda z: z ** 2 + c
+    """ Complex quadratic polynomial, function used for Mandelbrot fractal """
+    return lambda z: z ** 2 + c
 
 
 def get_model(model, depth, c):
-  """
-  Returns the fractal model function for a single pixel.
-  """
-  if model == "julia":
-    func = cqp(c)
-    return lambda x, y: fractal_eta(x + y * 1j, func, depth)
-  if model == "mandelbrot":
-    return lambda x, y: fractal_eta(0, cqp(x + y * 1j), depth)
-  raise ValueError("Fractal not found")
+    """
+    Returns the fractal model function for a single pixel.
+    """
+    if model == "julia":
+        func = cqp(c)
+        return lambda x, y: fractal_eta(x + y * 1j, func, depth)
+    if model == "mandelbrot":
+        return lambda x, y: fractal_eta(0, cqp(x + y * 1j), depth)
+    raise ValueError("Fractal not found")
 
 
 def generate_fractal(model, c=None, size=pair_reader(int)(DEFAULT_SIZE),
                      depth=int(DEFAULT_DEPTH), zoom=float(DEFAULT_ZOOM),
                      center=pair_reader(float)(DEFAULT_CENTER)):
-  """
-  2D Numpy Array with the fractal value for each pixel coordinate.
-  """
-  num_procs = multiprocessing.cpu_count()
-  print('CPU Count:', num_procs)
-  start = time.time()
+    """
+    2D Numpy Array with the fractal value for each pixel coordinate.
+    """
+    num_procs = multiprocessing.cpu_count()
+    print('CPU Count:', num_procs)
+    start = time.time()
 
-  # Create a pool of workers, one for each row
-  pool = multiprocessing.Pool(num_procs)
-  procs = [pool.apply_async(generate_row,
-                            [model, c, size, depth, zoom, center, row])
-           for row in range(size[1])]
+    # Create a pool of workers, one for each row
+    pool = multiprocessing.Pool(num_procs)
+    procs = [pool.apply_async(generate_row,
+                              [model, c, size, depth, zoom, center, row])
+             for row in range(size[1])]
 
-  # Generates the intensities for each pixel
-  img = pylab.array([row_proc.get() for row_proc in procs])
+    # Generates the intensities for each pixel
+    img = pylab.array([row_proc.get() for row_proc in procs])
 
-  print('Time taken:', time.time() - start)
-  return img
+    print('Time taken:', time.time() - start)
+    return img
 
 
 def generate_row(model, c, size, depth, zoom, center, row):
-  """
-  Generate a single row of fractal values, enabling shared workload.
-  """
-  func = get_model(model, depth, c)
-  width, height = size
-  cx, cy = center
-  side = max(width, height)
-  sidem1 = side - 1
-  deltax = (side - width) / 2 # Centralize
-  deltay = (side - height) / 2
-  y = (2 * (height - row + deltay) / sidem1 - 1) / zoom + cy
-  return [func((2 * (col + deltax) / sidem1 - 1) / zoom + cx, y)
-          for col in range(width)]
+    """
+    Generate a single row of fractal values, enabling shared workload.
+    """
+    func = get_model(model, depth, c)
+    width, height = size
+    cx, cy = center
+    side = max(width, height)
+    sidem1 = side - 1
+    deltax = (side - width) / 2  # Centralize
+    deltay = (side - height) / 2
+    y = (2 * (height - row + deltay) / sidem1 - 1) / zoom + cy
+    return [func((2 * (col + deltax) / sidem1 - 1) / zoom + cx, y)
+            for col in range(width)]
 
 
 def img2output(img, cmap=DEFAULT_COLORMAP, output=None, show=False):
-  """ Plots and saves the desired fractal raster image """
-  if output:
-    pylab.imsave(output, img, cmap=cmap)
-  if show:
-    pylab.imshow(img, cmap=cmap)
-    pylab.show()
+    """ Plots and saves the desired fractal raster image """
+    if output:
+        pylab.imsave(output, img, cmap=cmap)
+    if show:
+        pylab.imshow(img, cmap=cmap)
+        pylab.show()
 
 
 def call_kw(func, kwargs):
-  """ Call func(**kwargs) but remove the possible unused extra keys before """
-  keys = inspect.getargspec(func).args
-  kwfiltered = dict((k, v) for k, v in kwargs.items() if k in keys)
-  return func(**kwfiltered)
+    """ Call func(**kwargs) but remove the possible unused extra keys before """
+    keys = inspect.getargspec(func).args
+    kwfiltered = dict((k, v) for k, v in kwargs.items() if k in keys)
+    return func(**kwfiltered)
 
 
 def exec_command(kwargs):
-  """ Fractal command from a dictionary of keyword arguments (from CLI) """
-  kwargs["img"] = call_kw(generate_fractal, kwargs)
-  call_kw(img2output, kwargs)
+    """ Fractal command from a dictionary of keyword arguments (from CLI) """
+    kwargs["img"] = call_kw(generate_fractal, kwargs)
+    call_kw(img2output, kwargs)
 
 
 def cli_parse_args(args=None, namespace=None):
-  """
-  CLI (Command Line Interface) parsing based on ``ArgumentParser.parse_args``
-  from the ``argparse`` module.
-  """
-  # CLI interface description
-  parser = argparse.ArgumentParser(
-    description=__doc__,
-    epilog="by Danilo J. S. Bellini",
-    formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-  )
-  parser.add_argument("model", choices=["julia", "mandelbrot"],
-                      help="Fractal type/model")
-  parser.add_argument("c", nargs="*", default=argparse.SUPPRESS,
-                      help="Single Julia fractal complex-valued constant "
-                           "parameter (needed for julia, shouldn't appear "
-                           "for mandelbrot), e.g. -.7102 + .2698j (with the "
-                           "spaces), or perhaps with zeros and 'i' like "
-                           "-0.6 + 0.4i. If the argument parser gives "
-                           "any trouble, just add spaces between the numbers "
-                           "and their signals, like '- 0.6 + 0.4 j'")
-  parser.add_argument("-s", "--size", default=DEFAULT_SIZE,
-                      type=pair_reader(int),
-                      help="Size in pixels for the output file")
-  parser.add_argument("-d", "--depth", default=DEFAULT_DEPTH,
-                      type=int,
-                      help="Iteration depth, the step count limit")
-  parser.add_argument("-z", "--zoom", default=DEFAULT_ZOOM,
-                      type=float,
-                      help="Zoom factor, assuming data is shown in the "
-                           "[-1/zoom; 1/zoom] range for both dimensions, "
-                           "besides the central point displacement")
-  parser.add_argument("-c", "--center", default=DEFAULT_CENTER,
-                      type=pair_reader(float),
-                      help="Central point in the image")
-  parser.add_argument("-m", "--cmap", default=DEFAULT_COLORMAP,
-                      help="Matplotlib colormap name to be used")
-  parser.add_argument("-o", "--output", default=argparse.SUPPRESS,
-                      help="Output to a file, with the chosen extension, "
-                           "e.g. fractal.png")
-  parser.add_argument("--show", default=argparse.SUPPRESS,
-                      action="store_true",
-                      help="Shows the plot in the default Matplotlib backend")
+    """
+    CLI (Command Line Interface) parsing based on ``ArgumentParser.parse_args``
+    from the ``argparse`` module.
+    """
+    # CLI interface description
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        epilog="by Danilo J. S. Bellini",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("model", choices=["julia", "mandelbrot"],
+                        help="Fractal type/model")
+    parser.add_argument("c", nargs="*", default=argparse.SUPPRESS,
+                        help="Single Julia fractal complex-valued constant "
+                             "parameter (needed for julia, shouldn't appear "
+                             "for mandelbrot), e.g. -.7102 + .2698j (with the "
+                             "spaces), or perhaps with zeros and 'i' like "
+                             "-0.6 + 0.4i. If the argument parser gives "
+                             "any trouble, just add spaces between the numbers "
+                             "and their signals, like '- 0.6 + 0.4 j'")
+    parser.add_argument("-s", "--size", default=DEFAULT_SIZE,
+                        type=pair_reader(int),
+                        help="Size in pixels for the output file")
+    parser.add_argument("-d", "--depth", default=DEFAULT_DEPTH,
+                        type=int,
+                        help="Iteration depth, the step count limit")
+    parser.add_argument("-z", "--zoom", default=DEFAULT_ZOOM,
+                        type=float,
+                        help="Zoom factor, assuming data is shown in the "
+                             "[-1/zoom; 1/zoom] range for both dimensions, "
+                             "besides the central point displacement")
+    parser.add_argument("-c", "--center", default=DEFAULT_CENTER,
+                        type=pair_reader(float),
+                        help="Central point in the image")
+    parser.add_argument("-m", "--cmap", default=DEFAULT_COLORMAP,
+                        help="Matplotlib colormap name to be used")
+    parser.add_argument("-o", "--output", default=argparse.SUPPRESS,
+                        help="Output to a file, with the chosen extension, "
+                             "e.g. fractal.png")
+    parser.add_argument("--show", default=argparse.SUPPRESS,
+                        action="store_true",
+                        help="Shows the plot in the default Matplotlib backend")
 
-  # Process arguments
-  ns_parsed = parser.parse_args(args=args, namespace=namespace)
-  if ns_parsed.model == "julia" and "c" not in ns_parsed:
-    parser.error("Missing Julia constant")
-  if ns_parsed.model == "mandelbrot" and "c" in ns_parsed:
-    parser.error("Mandelbrot has no constant")
-  if "output" not in ns_parsed and "show" not in ns_parsed:
-    parser.error("Nothing to be done (no output file name nor --show)")
-  if "c" in ns_parsed:
-    try:
-      ns_parsed.c = complex("".join(ns_parsed.c).replace("i", "j"))
-    except ValueError as exc:
-      parser.error(exc)
+    # Process arguments
+    ns_parsed = parser.parse_args(args=args, namespace=namespace)
+    if ns_parsed.model == "julia" and "c" not in ns_parsed:
+        parser.error("Missing Julia constant")
+    if ns_parsed.model == "mandelbrot" and "c" in ns_parsed:
+        parser.error("Mandelbrot has no constant")
+    if "output" not in ns_parsed and "show" not in ns_parsed:
+        parser.error("Nothing to be done (no output file name nor --show)")
+    if "c" in ns_parsed:
+        try:
+            ns_parsed.c = complex("".join(ns_parsed.c).replace("i", "j"))
+        except ValueError as exc:
+            parser.error(exc)
 
-  return vars(ns_parsed)
+    return vars(ns_parsed)
+
 
 if __name__ == "__main__":
-  exec_command(cli_parse_args())
+    exec_command(cli_parse_args())

--- a/generate_examples.py
+++ b/generate_examples.py
@@ -6,96 +6,105 @@
 
 from fractal import Point, exec_command
 try:
-  from collections import OrderedDict
-except ImportError: # Python 2.6
-  from ordereddict import OrderedDict
+    from collections import OrderedDict
+except ImportError:  # Python 2.6
+    from ordereddict import OrderedDict
 
 # String formatting functions
 Point.__str__ = lambda self: "x".join(map(str, self))
-basic_str = lambda el: str(el).lstrip("(").rstrip(")") # Complex or model name
-item_str = lambda k, v: (basic_str(v) if k in ["model", "c"] else
-                         "{}={}".format(k, v))
-filename = lambda kwargs: "_".join(item_str(*pair) for pair in kwargs.items())
+
+
+def basic_str(el): return str(el).lstrip(
+    "(").rstrip(")")  # Complex or model name
+
+
+def item_str(k, v): return (basic_str(v) if k in ["model", "c"] else
+                            "{}={}".format(k, v))
+
+
+def filename(kwargs): return "_".join(item_str(*pair)
+                                      for pair in kwargs.items())
+
 
 # Example list
 kwargs_list = [
-  OrderedDict([("model", "julia"),
-               ("c", -.7102+.2698j),
-               ("size", Point(500, 300)),
-               ("depth", 512),
-               ("zoom", .65),
-  ]),
-  OrderedDict([("model", "julia"),
-               ("c", -1.037+.17j),
-               ("size", Point(600, 300)),
-               ("depth", 40),
-               ("zoom", .55),
-  ]),
-  OrderedDict([("model", "julia"),
-               ("c", -.644),
-               ("size", Point(300, 200)),
-               ("depth", 25),
-               ("zoom", .6),
-  ]),
-  OrderedDict([("model", "julia"),
-               ("c", -.7+.27015j),
-               ("size", Point(500, 300)),
-               ("depth", 512),
-               ("zoom", .6),
-  ]),
-  OrderedDict([("model", "julia"),
-               ("c", -.8+.156j),
-               ("size", Point(500, 300)),
-               ("depth", 512),
-               ("zoom", .6),
-  ]),
-  OrderedDict([("model", "julia"),
-               ("c", -.8+.156j),
-               ("size", Point(400, 230)),
-               ("depth", 50),
-               ("zoom", .65),
-  ]),
-  OrderedDict([("model", "julia"),
-               ("c", -.77777-.25j),
-               ("size", Point(527, 331)),
-               ("depth", 200),
-               ("zoom", .7),
-  ]),
-  OrderedDict([("model", "mandelbrot"),
-               ("size", Point(500, 500)),
-               ("depth", 80),
-               ("zoom", .8),
-               ("center", Point(-.75, 0)),
-  ]),
-  OrderedDict([("model", "mandelbrot"),
-               ("size", Point(300, 300)),
-               ("depth", 80),
-               ("zoom", 1.2),
-               ("center", Point(-1, 0)),
-  ]),
-  OrderedDict([("model", "mandelbrot"),
-               ("size", Point(400, 300)),
-               ("depth", 80),
-               ("zoom", 2),
-               ("center", Point(-1, 0)),
-  ]),
-  OrderedDict([("model", "mandelbrot"),
-               ("size", Point(500, 500)),
-               ("depth", 256),
-               ("zoom", 6.5),
-               ("center", Point(-1.2, .35)),
-  ]),
-  OrderedDict([("model", "mandelbrot"),
-               ("size", Point(600, 600)),
-               ("depth", 256),
-               ("zoom", 90),
-               ("center", Point(-1.255, .38)),
-  ]),
+    OrderedDict([("model", "julia"),
+                 ("c", -.7102+.2698j),
+                 ("size", Point(500, 300)),
+                 ("depth", 512),
+                 ("zoom", .65),
+                 ]),
+    OrderedDict([("model", "julia"),
+                 ("c", -1.037+.17j),
+                 ("size", Point(600, 300)),
+                 ("depth", 40),
+                 ("zoom", .55),
+                 ]),
+    OrderedDict([("model", "julia"),
+                 ("c", -.644),
+                 ("size", Point(300, 200)),
+                 ("depth", 25),
+                 ("zoom", .6),
+                 ]),
+    OrderedDict([("model", "julia"),
+                 ("c", -.7+.27015j),
+                 ("size", Point(500, 300)),
+                 ("depth", 512),
+                 ("zoom", .6),
+                 ]),
+    OrderedDict([("model", "julia"),
+                 ("c", -.8+.156j),
+                 ("size", Point(500, 300)),
+                 ("depth", 512),
+                 ("zoom", .6),
+                 ]),
+    OrderedDict([("model", "julia"),
+                 ("c", -.8+.156j),
+                 ("size", Point(400, 230)),
+                 ("depth", 50),
+                 ("zoom", .65),
+                 ]),
+    OrderedDict([("model", "julia"),
+                 ("c", -.77777-.25j),
+                 ("size", Point(527, 331)),
+                 ("depth", 200),
+                 ("zoom", .7),
+                 ]),
+    OrderedDict([("model", "mandelbrot"),
+                 ("size", Point(500, 500)),
+                 ("depth", 80),
+                 ("zoom", .8),
+                 ("center", Point(-.75, 0)),
+                 ]),
+    OrderedDict([("model", "mandelbrot"),
+                 ("size", Point(300, 300)),
+                 ("depth", 80),
+                 ("zoom", 1.2),
+                 ("center", Point(-1, 0)),
+                 ]),
+    OrderedDict([("model", "mandelbrot"),
+                 ("size", Point(400, 300)),
+                 ("depth", 80),
+                 ("zoom", 2),
+                 ("center", Point(-1, 0)),
+                 ]),
+    OrderedDict([("model", "mandelbrot"),
+                 ("size", Point(500, 500)),
+                 ("depth", 256),
+                 ("zoom", 6.5),
+                 ("center", Point(-1.2, .35)),
+                 ]),
+    OrderedDict([("model", "mandelbrot"),
+                 ("size", Point(600, 600)),
+                 ("depth", 256),
+                 ("zoom", 90),
+                 ("center", Point(-1.255, .38)),
+                 ]),
 ]
 
 # Creates all examples
 if __name__ == "__main__":
-  for kwargs in kwargs_list:
-    kwargs["output"] = "images/{}.png".format(filename(kwargs))
-    #kwargs["show"] = True
-    exec_command(kwargs)
+    for kwargs in kwargs_list:
+        kwargs["output"] = "images/{}.png".format(filename(kwargs))
+        #kwargs["show"] = True
+        exec_command(kwargs)

--- a/generate_readme.py
+++ b/generate_readme.py
@@ -5,7 +5,8 @@
 # @author: Danilo de Jesus da Silva Bellini
 
 from __future__ import unicode_literals
-import os, io
+import os
+import io
 from test_fractal import show_parameters
 
 template_string = """..
@@ -70,15 +71,15 @@ By Danilo J. S. Bellini
 """
 
 kwargs = {
-  "listdir": os.listdir,
-  "sorted": sorted,
-  "show_parameters": show_parameters,
+    "listdir": os.listdir,
+    "sorted": sorted,
+    "show_parameters": show_parameters,
 }
 
 if __name__ == "__main__":
-  import jinja2
-  template = jinja2.Template(template_string)
-  readme_data = template.render(**kwargs)
+    import jinja2
+    template = jinja2.Template(template_string)
+    readme_data = template.render(**kwargs)
 
-  with io.open("README.rst", "w", encoding="utf-8", newline="\r\n") as readme:
-    readme.write(readme_data)
+    with io.open("README.rst", "w", encoding="utf-8", newline="\r\n") as readme:
+        readme.write(readme_data)

--- a/setup.py
+++ b/setup.py
@@ -1,24 +1,26 @@
 #!/usr/bin/env python
-import os, setuptools, re
+import os
+import setuptools
+import re
 
 url = "https://github.com/danilobellini/fractal"
 
 metadata = {
-  "name": "fractal",
-  "version": "0.1.0.dev",
-  "author": "Danilo J. S. Bellini",
-  "description": "Fractals in Python",
-  "author_email": "danilo.bellini@gmail.com",
-  "url": url,
-  "license": "MIT",
-  "py_modules": ["fractal"],
-  "install_requires": ["matplotlib"],
+    "name": "fractal",
+    "version": "0.1.0.dev",
+    "author": "Danilo J. S. Bellini",
+    "description": "Fractals in Python",
+    "author_email": "danilo.bellini@gmail.com",
+    "url": url,
+    "license": "MIT",
+    "py_modules": ["fractal"],
+    "install_requires": ["matplotlib"],
 }
 
 with open(os.path.join(os.path.dirname(__file__), "README.rst")) as f:
-  metadata["long_description"] = re.sub(r"(\.\. (?:image|_\S+):+\s*)([^: ]+)",
-                                        r"\1{0}/raw/master/\2".format(url),
-                                        f.read())
+    metadata["long_description"] = re.sub(r"(\.\. (?:image|_\S+):+\s*)([^: ]+)",
+                                          r"\1{0}/raw/master/\2".format(url),
+                                          f.read())
 
 metadata["classifiers"] = """
 Development Status :: 3 - Alpha

--- a/test_fractal.py
+++ b/test_fractal.py
@@ -4,7 +4,10 @@
 # License is MIT, see COPYING.txt for more details.
 # @author: Danilo de Jesus da Silva Bellini
 
-import os, re, pytest, pylab
+import os
+import re
+import pytest
+import pylab
 from fractal import generate_fractal, call_kw, cli_parse_args, img2output
 from io import BytesIO
 from pylab import imread, imsave, array
@@ -14,27 +17,29 @@ p = pytest.mark.parametrize
 # Helper functions
 #
 
+
 def show_parameters(fname):
-  """ String with CLI args to show the fractal with the given ``fname`` """
-  re_complex = re.compile("(?:([+-]?\s*[0-9.]+))?\s*"
-                          "(?:([+-]\s*[0-9.]+)\s*)?(.*)")
-  def part_generator():
-    for part in fname.rsplit(".", 1)[0].split("_"):
-      if "=" in part:
-        yield "--" + part
-      else:
-        yield " ".join(filter(lambda x: x, re_complex.match(part).groups()))
-    yield "--show"
-  return " ".join(part_generator())
+    """ String with CLI args to show the fractal with the given ``fname`` """
+    re_complex = re.compile("(?:([+-]?\s*[0-9.]+))?\s*"
+                            "(?:([+-]\s*[0-9.]+)\s*)?(.*)")
+
+    def part_generator():
+        for part in fname.rsplit(".", 1)[0].split("_"):
+            if "=" in part:
+                yield "--" + part
+            else:
+                yield " ".join(filter(lambda x: x, re_complex.match(part).groups()))
+        yield "--show"
+    return " ".join(part_generator())
 
 
 def to_dict_params(fname):
-  """ Get full kwargs from file name """
-  return cli_parse_args(show_parameters(fname).split())
+    """ Get full kwargs from file name """
+    return cli_parse_args(show_parameters(fname).split())
 
 
-def almost_equal_diff(a, b, max_diff = 2e-2):
-  return abs(a - b) < max_diff
+def almost_equal_diff(a, b, max_diff=2e-2):
+    return abs(a - b) < max_diff
 
 
 #
@@ -43,81 +48,84 @@ def almost_equal_diff(a, b, max_diff = 2e-2):
 
 @p("fname", os.listdir("images"))
 def test_file_image(fname):
-  ext = os.path.splitext(fname)[-1][len(os.path.extsep):]
-  kwargs = to_dict_params(fname)
+    ext = os.path.splitext(fname)[-1][len(os.path.extsep):]
+    kwargs = to_dict_params(fname)
 
-  # Creates the image in memory
-  mem = BytesIO()
-  fractal_data = call_kw(generate_fractal, kwargs)
-  imsave(mem, fractal_data, cmap=kwargs["cmap"], format=ext)
-  mem.seek(0) # Return stream position back for reading
+    # Creates the image in memory
+    mem = BytesIO()
+    fractal_data = call_kw(generate_fractal, kwargs)
+    imsave(mem, fractal_data, cmap=kwargs["cmap"], format=ext)
+    mem.seek(0)  # Return stream position back for reading
 
-  # Comparison pixel-by-pixel
-  img_file = imread("images/" + fname)
-  img_mem = imread(mem, format=ext)
-  assert img_file.tolist() == img_mem.tolist()
+    # Comparison pixel-by-pixel
+    img_file = imread("images/" + fname)
+    img_mem = imread(mem, format=ext)
+    assert img_file.tolist() == img_mem.tolist()
 
 
-def test_generate_fractal_wrong_name(): # Only possible from API
-  with pytest.raises(ValueError):
-    generate_fractal(model="julia_")
+def test_generate_fractal_wrong_name():  # Only possible from API
+    with pytest.raises(ValueError):
+        generate_fractal(model="julia_")
 
 
 class TestImg2Output(object):
-  """ Tests interface with Matplotlib """
+    """ Tests interface with Matplotlib """
 
-  def test_file_as_memory_output(self):
-    img = array([[0, 1], [1, 0], [.5, .3]])
-    mem = BytesIO()
-    img2output(img, cmap="gray", output=mem)
-    mem.seek(0)
-    png_data = imread(mem)
-    for row_png, row_img in zip(png_data, img):
-      for pixel_png, pixel_img in zip(row_png, row_img):
-        assert almost_equal_diff(pixel_png[-1], 1.)
-        for pixel in pixel_png[:-1]:
-          assert almost_equal_diff(pixel, pixel_img)
+    def test_file_as_memory_output(self):
+        img = array([[0, 1], [1, 0], [.5, .3]])
+        mem = BytesIO()
+        img2output(img, cmap="gray", output=mem)
+        mem.seek(0)
+        png_data = imread(mem)
+        for row_png, row_img in zip(png_data, img):
+            for pixel_png, pixel_img in zip(row_png, row_img):
+                assert almost_equal_diff(pixel_png[-1], 1.)
+                for pixel in pixel_png[:-1]:
+                    assert almost_equal_diff(pixel, pixel_img)
 
-  def test_show(self, monkeypatch):
-    def imshow(img, cmap):
-      assert not imshow.called
-      assert cmap == "gray"
-      assert img.shape == (3, 2)
-      imshow.called = True
-    def show():
-      assert imshow.called
-    monkeypatch.setattr(pylab, "imshow", imshow)
-    monkeypatch.setattr(pylab, "show", show)
+    def test_show(self, monkeypatch):
+        def imshow(img, cmap):
+            assert not imshow.called
+            assert cmap == "gray"
+            assert img.shape == (3, 2)
+            imshow.called = True
 
-    img = array([[0, 1], [1, 0], [.5, .3]])
-    imshow.called = False
-    assert img2output(img, cmap="gray", show=True) is None
+        def show():
+            assert imshow.called
+        monkeypatch.setattr(pylab, "imshow", imshow)
+        monkeypatch.setattr(pylab, "show", show)
 
-  def test_show_and_output(self, monkeypatch):
-    def imsave(output, img, cmap): # Should be called first
-      assert not imsave.called
-      assert not imshow.called
-      assert cmap == "something"
-      assert img.shape == (2, 4)
-      imsave.called = True
-      output.write(b"Data!")
-    def imshow(img, cmap):
-      assert imsave.called
-      assert not imshow.called
-      assert cmap == "something"
-      assert img.shape == (2, 4)
-      imshow.called = True
-    def show():
-      assert imsave.called
-      assert imshow.called
-    monkeypatch.setattr(pylab, "imsave", imsave)
-    monkeypatch.setattr(pylab, "imshow", imshow)
-    monkeypatch.setattr(pylab, "show", show)
+        img = array([[0, 1], [1, 0], [.5, .3]])
+        imshow.called = False
+        assert img2output(img, cmap="gray", show=True) is None
 
-    img = array([[5, -1, 4, .0003], [.1, 0., 47.8, -8]])
-    imshow.called = False
-    imsave.called = False
-    mem = BytesIO()
-    assert img2output(img, cmap="something", output=mem, show=True) is None
-    mem.seek(0)
-    assert mem.read() == b"Data!"
+    def test_show_and_output(self, monkeypatch):
+        def imsave(output, img, cmap):  # Should be called first
+            assert not imsave.called
+            assert not imshow.called
+            assert cmap == "something"
+            assert img.shape == (2, 4)
+            imsave.called = True
+            output.write(b"Data!")
+
+        def imshow(img, cmap):
+            assert imsave.called
+            assert not imshow.called
+            assert cmap == "something"
+            assert img.shape == (2, 4)
+            imshow.called = True
+
+        def show():
+            assert imsave.called
+            assert imshow.called
+        monkeypatch.setattr(pylab, "imsave", imsave)
+        monkeypatch.setattr(pylab, "imshow", imshow)
+        monkeypatch.setattr(pylab, "show", show)
+
+        img = array([[5, -1, 4, .0003], [.1, 0., 47.8, -8]])
+        imshow.called = False
+        imsave.called = False
+        mem = BytesIO()
+        assert img2output(img, cmap="something", output=mem, show=True) is None
+        mem.seek(0)
+        assert mem.read() == b"Data!"


### PR DESCRIPTION
Earlier most files used 2 space indentation, while conftest.py used 4 spaces. In this fork all files use 4 space indentation which provides greater readability for future edits and contributions.